### PR TITLE
Check project syntax errors

### DIFF
--- a/project/src/pages/zh-tw/guide/[id].astro
+++ b/project/src/pages/zh-tw/guide/[id].astro
@@ -1,7 +1,13 @@
 ---
+import { fetchGuideData } from '../../../utils/dataFetcher';
+import { 
+  getLocalizedText, 
+  defaultLanguage
+} from '../../../utils/language';
+import LanguageSelector from '../../../components/LanguageSelector.astro';
+import Layout from '../../../layouts/Layout.astro';
+
 export async function getStaticPaths() {
-  const { fetchGuideData } = await import('../../../utils/dataFetcher');
-  
   try {
     const guideItems = await fetchGuideData();
     
@@ -16,15 +22,13 @@ export async function getStaticPaths() {
   }
 }
 
-import { 
-  getLocalizedText, 
-  defaultLanguage
-} from '../../../utils/language';
-import LanguageSelector from '../../../components/LanguageSelector.astro';
-import Layout from '../../../layouts/Layout.astro';
-
 const currentLanguage = 'zh-tw';
 const { guideData } = Astro.props;
+
+// Add null check for guideData
+if (!guideData) {
+  return Astro.redirect('/zh-tw/');
+}
 
 const homeText = '首頁';
 const overviewText = '概要';


### PR DESCRIPTION
Fix Astro build error by moving imports and adding a null check for guide data.

The Astro build failed with an "Unexpected 't'" error because `import` statements were incorrectly placed inside the `getStaticPaths` function within the frontmatter. Astro requires imports to be at the top level of the frontmatter. Additionally, a null check for `guideData` was added to prevent runtime errors if the data is not found, ensuring a graceful redirect.

---
<a href="https://cursor.com/background-agent?bcId=bc-34e72552-b810-4dfd-83ea-58fa98ba69b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34e72552-b810-4dfd-83ea-58fa98ba69b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

